### PR TITLE
Web builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
       # We use the setup-emsdk action to install the Emscripten SDK
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v11
+        uses: mymindstorm/setup-emsdk@v12
         with:
           version: ${{ env.EMSCRIPTEN_VERSION }}
           actions-cache-folder: ${{ env.EMSCRIPTEN_CACHE_FOLDER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
           cd emsdk
           ./emsdk install ${{ env.EMSCRIPTEN_VERSION }}
           ./emsdk activate ${{ env.EMSCRIPTEN_VERSION }}
-          source ./emsdk_env.sh
       # We download the prepackaged version of Raylib that works for emscripten
       # If we didn't download this version, we would need to compile Raylib for HTML5 builds
       - name: Install Raylib for Web
@@ -87,7 +86,9 @@ jobs:
           mv raylibwrapper/raylib-${{ env.RAYLIB_VERSION }}_webassembly raylib
       # We build with our specific CI build command, which statically links Raylib
       - name: Build for Web
-        run: make build-web
+        run: |
+          source ./emsdk/emsdk_env.sh
+          make build-web
         env:
           WORKSPACE_DIR: ${{ github.workspace }}
       # We then zip the game

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on: [push]
 
 env:
   RAYLIB_VERSION: 4.2.0
+  EMSCRIPTEN_VERSION: 3.1.32
+  EMSCRIPTEN_CACHE_FOLDER: emsdk-cache
   GAME_NAME: ${{ github.event.repository.name }}
 
 jobs:
@@ -54,6 +56,38 @@ jobs:
       # We then zip the game with 7z as it's already installed in the shared runner
       - name: Zip game build on Mac
         run: cd build && 7z a -tzip ${{ env.GAME_NAME }}.zip *
+      # Upload the artifacts for each OS
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.GAME_NAME }}-${{ runner.os }}
+          path: build/${{ env.GAME_NAME }}.zip
+
+  build-web:
+    runs-on: ubuntu-22.04
+    if: contains(github.event.head_commit.message, 'skip-web') == false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      # We use the setup-emsdk action to install the Emscripten SDK
+      - name: Setup emsdk
+        uses: mymindstorm/setup-emsdk@v11
+        with:
+          version: ${{ env.EMSCRIPTEN_VERSION }}
+          actions-cache-folder: ${{ env.EMSCRIPTEN_CACHE_FOLDER }}
+      # We download the prepackaged version of Raylib that works for emscripten
+      # If we didn't download this version, we would need to compile Raylib for HTML5 builds
+      - name: Install Raylib for Web
+        run: |
+          curl -L https://github.com/raysan5/raylib/releases/download/${{ env.RAYLIB_VERSION }}/raylib-${{ env.RAYLIB_VERSION }}_webassembly.zip --output raylib.zip
+          unzip raylib.zip raylibwrapper
+          mv raylibwrapper/raylib-${{ env.RAYLIB_VERSION }}_webassembly raylib
+      # We build with our specific CI build command, which statically links Raylib
+      - name: Build for Web
+        run: make build-web
+      # We then zip the game
+      - name: Zip game build for Web
+        run: cd build/${{ env.GAME_NAME }} && zip -r ${{ env.GAME_NAME }}.zip *
       # Upload the artifacts for each OS
       - name: Archive artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 env:
   RAYLIB_VERSION: 4.2.0
-  EMSCRIPTEN_VERSION: 3.1.25
+  EMSCRIPTEN_VERSION: 3.1.15
   EMSCRIPTEN_CACHE_FOLDER: emsdk-cache
   GAME_NAME: ${{ github.event.repository.name }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
         run: |
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
-          ./emsdk update
           ./emsdk install ${{ env.EMSCRIPTEN_VERSION }}
           ./emsdk activate ${{ env.EMSCRIPTEN_VERSION }}
           source ./emsdk_env.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,10 @@ jobs:
           WORKSPACE_DIR: ${{ github.workspace }}
       # We then zip the game
       - name: Zip game build for Web
-        run: cd build/${{ env.GAME_NAME }} && zip -r ${{ env.GAME_NAME }}.zip *
+        run: cd build && zip -r ${{ env.GAME_NAME }}.zip *
       # Upload the artifacts for each OS
       - name: Archive artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.GAME_NAME }}-${{ runner.os }}
+          name: ${{ env.GAME_NAME }}-Web
           path: build/${{ env.GAME_NAME }}.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      # We use the setup-emsdk action to install the Emscripten SDK
-      - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v12
-        with:
-          version: ${{ env.EMSCRIPTEN_VERSION }}
-          actions-cache-folder: ${{ env.EMSCRIPTEN_CACHE_FOLDER }}
+      # The setup-emsdk builds but app doesn't work, and the default Ubuntu version throws an error
+      # So we install the way emscripten recommends
+      - name: Install Emscripten
+        run: |
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk update
+          ./emsdk install ${{ env.EMSCRIPTEN_VERSION }}
+          ./emsdk activate ${{ env.EMSCRIPTEN_VERSION }}
+          source ./emsdk_env.sh
       # We download the prepackaged version of Raylib that works for emscripten
       # If we didn't download this version, we would need to compile Raylib for HTML5 builds
       - name: Install Raylib for Web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 env:
   RAYLIB_VERSION: 4.2.0
-  EMSCRIPTEN_VERSION: 3.1.32
+  EMSCRIPTEN_VERSION: 3.1.25
   EMSCRIPTEN_CACHE_FOLDER: emsdk-cache
   GAME_NAME: ${{ github.event.repository.name }}
 
@@ -69,9 +69,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      # Install emscripten via Ubuntu packages
+      # We use the setup-emsdk action to install the Emscripten SDK
       - name: Setup emsdk
-        run: sudo apt-get install emscripten
+        uses: mymindstorm/setup-emsdk@v11
+        with:
+          version: ${{ env.EMSCRIPTEN_VERSION }}
+          actions-cache-folder: ${{ env.EMSCRIPTEN_CACHE_FOLDER }}
       # We download the prepackaged version of Raylib that works for emscripten
       # If we didn't download this version, we would need to compile Raylib for HTML5 builds
       - name: Install Raylib for Web
@@ -79,7 +82,6 @@ jobs:
           curl -L https://github.com/raysan5/raylib/releases/download/${{ env.RAYLIB_VERSION }}/raylib-${{ env.RAYLIB_VERSION }}_webassembly.zip --output raylib.zip
           unzip raylib.zip -d raylibwrapper
           mv raylibwrapper/raylib-${{ env.RAYLIB_VERSION }}_webassembly raylib
-          rm -rf raylibwrapper raylib.zip
       # We build with our specific CI build command, which statically links Raylib
       - name: Build for Web
         run: make build-web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install Raylib for Web
         run: |
           curl -L https://github.com/raysan5/raylib/releases/download/${{ env.RAYLIB_VERSION }}/raylib-${{ env.RAYLIB_VERSION }}_webassembly.zip --output raylib.zip
-          unzip raylib.zip raylibwrapper
+          unzip raylib.zip -d raylibwrapper
           mv raylibwrapper/raylib-${{ env.RAYLIB_VERSION }}_webassembly raylib
       # We build with our specific CI build command, which statically links Raylib
       - name: Build for Web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
       # We build with our specific CI build command, which statically links Raylib
       - name: Build for Web
         run: make build-web
+        env:
+          WORKSPACE_DIR: ${{ github.workspace }}
       # We then zip the game
       - name: Zip game build for Web
         run: cd build/${{ env.GAME_NAME }} && zip -r ${{ env.GAME_NAME }}.zip *

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ env:
   EMSCRIPTEN_VERSION: 3.1.32
   EMSCRIPTEN_CACHE_FOLDER: emsdk-cache
   GAME_NAME: ${{ github.event.repository.name }}
+  NODE_VERSION: 18.x
 
 jobs:
   build-mac:
@@ -75,6 +76,11 @@ jobs:
         with:
           version: ${{ env.EMSCRIPTEN_VERSION }}
           actions-cache-folder: ${{ env.EMSCRIPTEN_CACHE_FOLDER }}
+      # Update Node.js used by Emscripten
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       # We download the prepackaged version of Raylib that works for emscripten
       # If we didn't download this version, we would need to compile Raylib for HTML5 builds
       - name: Install Raylib for Web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ env:
   EMSCRIPTEN_VERSION: 3.1.32
   EMSCRIPTEN_CACHE_FOLDER: emsdk-cache
   GAME_NAME: ${{ github.event.repository.name }}
-  NODE_VERSION: 18.x
 
 jobs:
   build-mac:
@@ -76,11 +75,6 @@ jobs:
         with:
           version: ${{ env.EMSCRIPTEN_VERSION }}
           actions-cache-folder: ${{ env.EMSCRIPTEN_CACHE_FOLDER }}
-      # Update Node.js used by Emscripten
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
       # We download the prepackaged version of Raylib that works for emscripten
       # If we didn't download this version, we would need to compile Raylib for HTML5 builds
       - name: Install Raylib for Web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      # We use the setup-emsdk action to install the Emscripten SDK
+      # Install emscripten via Ubuntu packages
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v11
-        with:
-          version: ${{ env.EMSCRIPTEN_VERSION }}
-          actions-cache-folder: ${{ env.EMSCRIPTEN_CACHE_FOLDER }}
+        run: sudo apt-get install emscripten
       # We download the prepackaged version of Raylib that works for emscripten
       # If we didn't download this version, we would need to compile Raylib for HTML5 builds
       - name: Install Raylib for Web
@@ -82,6 +79,7 @@ jobs:
           curl -L https://github.com/raysan5/raylib/releases/download/${{ env.RAYLIB_VERSION }}/raylib-${{ env.RAYLIB_VERSION }}_webassembly.zip --output raylib.zip
           unzip raylib.zip -d raylibwrapper
           mv raylibwrapper/raylib-${{ env.RAYLIB_VERSION }}_webassembly raylib
+          rm -rf raylibwrapper raylib.zip
       # We build with our specific CI build command, which statically links Raylib
       - name: Build for Web
         run: make build-web

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ INCFLAGS_CI_WIN = -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/li
 INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib/libraylib.a -I${WORKSPACE_DIR}/src -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
 
 SRC = src/*.cpp
-SRC_WEB = src/main.cpp
 BUILDDIR = build
 APP_NAME = $(shell basename "$(CURDIR)")
 export APP_NAME
@@ -34,7 +33,7 @@ build-win-ci: $(BUILDDIR)
 	$(CXX) $(CFLAGS) -static-libgcc -static-libstdc++ -static -lpthread $(INCFLAGS_CI_WIN) $(SRC) -o $(TARGET_WIN) $(LDFLAGS_WIN)
 
 build-web: $(BUILDDIR)
-	$(ECC) -o $(BUILDDIR)/$(APP_NAME)/index.html $(SRC_WEB) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
+	$(ECC) -o $(BUILDDIR)/$(APP_NAME)/index.html $(SRC) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
 
 run-mac:
 	$(TARGET_MAC)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ INCFLAGS_CI_WIN = -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/li
 INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib/libraylib.a -I${WORKSPACE_DIR}/src -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
 
 SRC = src/*.cpp
-SRC_WEB = src/main.cpp
 BUILDDIR = build
 APP_NAME = $(shell basename "$(CURDIR)")
 export APP_NAME
@@ -35,7 +34,7 @@ build-win-ci: $(BUILDDIR)
 	$(CXX) $(CFLAGS) -static-libgcc -static-libstdc++ -static -lpthread $(INCFLAGS_CI_WIN) $(SRC) -o $(TARGET_WIN) $(LDFLAGS_WIN)
 
 build-web: $(BUILDDIR)
-	$(ECC) -o $(TARGET_WEB) $(SRC_WEB) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
+	$(ECC) -o $(TARGET_WEB) $(SRC) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
 
 run-mac:
 	$(TARGET_MAC)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 CC = cc
 CXX = g++
+ECC = emcc
 CFLAGS = -std=c++11
+ECCFLAGS = -Os -Wall
 LDFLAGS_MAC = -framework IOKit -framework Cocoa -framework OpenGL `pkg-config --libs raylib`
 LDFLAGS_MAC_CI = -framework CoreVideo -framework IOKit -framework Cocoa -framework GLUT -framework OpenGL libraylib.a
 LDFLAGS_WIN = -lraylib -lopengl32 -lgdi32 -lwinmm -mwindows
 INCFLAGS_WIN = -IC:/raylib/raylib/src
-INCFLAGS_WIN_CI = -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
+INCFLAGS_CI_WIN = -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
+INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib -I. -I${WORKSPACE_DIR}/raylib/include -L. -L${WORKSPACE_DIR}/raylib/lib
+
 SRC = src/*.cpp
 BUILDDIR = build
 APP_NAME = $(shell basename "$(CURDIR)")
@@ -26,7 +30,10 @@ build-win: $(BUILDDIR)
 	$(CXX) $(CFLAGS) -static-libgcc -static-libstdc++ $(INCFLAGS_WIN) $(SRC) -o $(TARGET_WIN) $(LDFLAGS_WIN)
 
 build-win-ci: $(BUILDDIR)
-	$(CXX) $(CFLAGS) -static-libgcc -static-libstdc++ -static -lpthread $(INCFLAGS_WIN_CI) $(SRC) -o $(TARGET_WIN) $(LDFLAGS_WIN)
+	$(CXX) $(CFLAGS) -static-libgcc -static-libstdc++ -static -lpthread $(INCFLAGS_CI_WIN) $(SRC) -o $(TARGET_WIN) $(LDFLAGS_WIN)
+
+build-web: $(BUILDDIR)
+	$(ECC) -o $(BUILDDIR)/$(APP_NAME)/index.html $(SRC) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
 
 run-mac:
 	$(TARGET_MAC)

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ APP_NAME = $(shell basename "$(CURDIR)")
 export APP_NAME
 TARGET_MAC = $(BUILDDIR)/$(APP_NAME).app
 TARGET_WIN = $(BUILDDIR)/$(APP_NAME).exe
+TARGET_WEB = $(BUILDDIR)/index.html
 
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
@@ -33,7 +34,7 @@ build-win-ci: $(BUILDDIR)
 	$(CXX) $(CFLAGS) -static-libgcc -static-libstdc++ -static -lpthread $(INCFLAGS_CI_WIN) $(SRC) -o $(TARGET_WIN) $(LDFLAGS_WIN)
 
 build-web: $(BUILDDIR)
-	$(ECC) -o $(BUILDDIR)/$(APP_NAME)/index.html $(SRC) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
+	$(ECC) -o $(TARGET_WEB) $(SRC) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
 
 run-mac:
 	$(TARGET_MAC)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS_MAC_CI = -framework CoreVideo -framework IOKit -framework Cocoa -framewo
 LDFLAGS_WIN = -lraylib -lopengl32 -lgdi32 -lwinmm -mwindows
 INCFLAGS_WIN = -IC:/raylib/raylib/src
 INCFLAGS_CI_WIN = -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
-INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib -I. -I${WORKSPACE_DIR}/raylib/include -L. -L${WORKSPACE_DIR}/raylib/lib
+INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib/libraylib.a -I. -I${WORKSPACE_DIR}/raylib/include -L. -L${WORKSPACE_DIR}/raylib/lib
 
 SRC = src/*.cpp
 BUILDDIR = build

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS_MAC_CI = -framework CoreVideo -framework IOKit -framework Cocoa -framewo
 LDFLAGS_WIN = -lraylib -lopengl32 -lgdi32 -lwinmm -mwindows
 INCFLAGS_WIN = -IC:/raylib/raylib/src
 INCFLAGS_CI_WIN = -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
-INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib/libraylib.a -I./src -I${WORKSPACE_DIR}/raylib/include -L. -L${WORKSPACE_DIR}/raylib/lib
+INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib/libraylib.a -I${WORKSPACE_DIR}/src -I${WORKSPACE_DIR}/raylib/include -L. -L${WORKSPACE_DIR}/raylib/lib
 
 SRC = src/*.cpp
 BUILDDIR = build

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ LDFLAGS_MAC_CI = -framework CoreVideo -framework IOKit -framework Cocoa -framewo
 LDFLAGS_WIN = -lraylib -lopengl32 -lgdi32 -lwinmm -mwindows
 INCFLAGS_WIN = -IC:/raylib/raylib/src
 INCFLAGS_CI_WIN = -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
-INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib/libraylib.a -I${WORKSPACE_DIR}/src -I${WORKSPACE_DIR}/raylib/include -L. -L${WORKSPACE_DIR}/raylib/lib
+INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib/libraylib.a -I${WORKSPACE_DIR}/src -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
 
 SRC = src/*.cpp
+SRC_WEB = src/main.cpp
 BUILDDIR = build
 APP_NAME = $(shell basename "$(CURDIR)")
 export APP_NAME
@@ -33,7 +34,7 @@ build-win-ci: $(BUILDDIR)
 	$(CXX) $(CFLAGS) -static-libgcc -static-libstdc++ -static -lpthread $(INCFLAGS_CI_WIN) $(SRC) -o $(TARGET_WIN) $(LDFLAGS_WIN)
 
 build-web: $(BUILDDIR)
-	$(ECC) -o $(BUILDDIR)/$(APP_NAME)/index.html $(SRC) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
+	$(ECC) -o $(BUILDDIR)/$(APP_NAME)/index.html $(SRC_WEB) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
 
 run-mac:
 	$(TARGET_MAC)

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ INCFLAGS_CI_WIN = -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/li
 INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib/libraylib.a -I${WORKSPACE_DIR}/src -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
 
 SRC = src/*.cpp
+SRC_WEB = src/main.cpp
 BUILDDIR = build
 APP_NAME = $(shell basename "$(CURDIR)")
 export APP_NAME
@@ -34,7 +35,7 @@ build-win-ci: $(BUILDDIR)
 	$(CXX) $(CFLAGS) -static-libgcc -static-libstdc++ -static -lpthread $(INCFLAGS_CI_WIN) $(SRC) -o $(TARGET_WIN) $(LDFLAGS_WIN)
 
 build-web: $(BUILDDIR)
-	$(ECC) -o $(TARGET_WEB) $(SRC) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
+	$(ECC) -o $(TARGET_WEB) $(SRC_WEB) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
 
 run-mac:
 	$(TARGET_MAC)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS_MAC_CI = -framework CoreVideo -framework IOKit -framework Cocoa -framewo
 LDFLAGS_WIN = -lraylib -lopengl32 -lgdi32 -lwinmm -mwindows
 INCFLAGS_WIN = -IC:/raylib/raylib/src
 INCFLAGS_CI_WIN = -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
-INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib/libraylib.a -I. -I${WORKSPACE_DIR}/raylib/include -L. -L${WORKSPACE_DIR}/raylib/lib
+INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib/libraylib.a -I./src -I${WORKSPACE_DIR}/raylib/include -L. -L${WORKSPACE_DIR}/raylib/lib
 
 SRC = src/*.cpp
 BUILDDIR = build

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ CC = cc
 CXX = g++
 EXX = em++
 CFLAGS = -std=c++11
-EXXFLAGS = -Os -Wall -s USE_GLFW=3
+EXXFLAGS = -Os -Wall -sUSE_GLFW=3 -sWASM=1
 LDFLAGS_MAC = -framework IOKit -framework Cocoa -framework OpenGL `pkg-config --libs raylib`
 LDFLAGS_MAC_CI = -framework CoreVideo -framework IOKit -framework Cocoa -framework GLUT -framework OpenGL libraylib.a
 LDFLAGS_WIN = -lraylib -lopengl32 -lgdi32 -lwinmm -mwindows
 INCFLAGS_WIN = -IC:/raylib/raylib/src
 INCFLAGS_CI_WIN = -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
-INCFLAGS_CI_WEB = ${WORKSPACE_DIR}/raylib/lib/libraylib.a -I${WORKSPACE_DIR}/src -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/lib
+INCFLAGS_CI_WEB = raylib/lib/libraylib.a -Iraylib/include -Isrc -Lraylib/lib
 
 SRC = src/*.cpp
 BUILDDIR = build

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ INCFLAGS_WIN_CI = -I${WORKSPACE_DIR}/raylib/include -L${WORKSPACE_DIR}/raylib/li
 SRC = src/*.cpp
 BUILDDIR = build
 APP_NAME = $(shell basename "$(CURDIR)")
+export APP_NAME
 TARGET_MAC = $(BUILDDIR)/$(APP_NAME).app
 TARGET_WIN = $(BUILDDIR)/$(APP_NAME).exe
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CC = cc
 CXX = g++
-ECC = emcc
+EXX = em++
 CFLAGS = -std=c++11
-ECCFLAGS = -Os -Wall
+EXXFLAGS = -Os -Wall -s USE_GLFW=3
 LDFLAGS_MAC = -framework IOKit -framework Cocoa -framework OpenGL `pkg-config --libs raylib`
 LDFLAGS_MAC_CI = -framework CoreVideo -framework IOKit -framework Cocoa -framework GLUT -framework OpenGL libraylib.a
 LDFLAGS_WIN = -lraylib -lopengl32 -lgdi32 -lwinmm -mwindows
@@ -34,7 +34,7 @@ build-win-ci: $(BUILDDIR)
 	$(CXX) $(CFLAGS) -static-libgcc -static-libstdc++ -static -lpthread $(INCFLAGS_CI_WIN) $(SRC) -o $(TARGET_WIN) $(LDFLAGS_WIN)
 
 build-web: $(BUILDDIR)
-	$(ECC) -o $(TARGET_WEB) $(SRC) $(ECCFLAGS) $(INCFLAGS_CI_WEB) -s USE_GLFW=3 -DPLATFORM_WEB
+	$(EXX) $(EXXFLAGS) $(SRC) -DPLATFORM_WEB $(INCFLAGS_CI_WEB) -o $(TARGET_WEB)
 
 run-mac:
 	$(TARGET_MAC)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,9 +25,6 @@ int main()
   const int screenHeight = 768;
   InitWindow(screenWidth, screenHeight, getenv("APP_NAME"));
 
-  // Initialize square position and size
-  Rectangle square = {screenWidth / 2 - 20, screenHeight / 2 - 20, 40, 40};
-
   // Set up camera
   camera.position = (Vector3){0.0f, 10.0f, 10.0f}; // Camera position
   camera.target = (Vector3){0.0f, 0.0f, 0.0f};     // Camera looking at point

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,11 @@
 #include "raylib.h"
 #include "raymath.h"
+#include <stdlib.h>
 #include "Player.h"
+
+#if defined(PLATFORM_WEB)
+#include <emscripten/emscripten.h>
+#endif
 
 // Global variables
 static Camera3D camera = {0};
@@ -9,6 +14,7 @@ static Vector3 playerVelocity = {0.0f, 0.0f, 0.0f};
 static const float playerSpeed = 5.0f;
 
 // Function declarations
+static void UpdateAndDrawFrame();
 static void UpdateGame();
 static void DrawGame();
 
@@ -17,7 +23,7 @@ int main()
   // Initialize Raylib window
   const int screenWidth = 1024;
   const int screenHeight = 768;
-  InitWindow(screenWidth, screenHeight, "Moving Cube");
+  InitWindow(screenWidth, screenHeight, getenv("APP_NAME"));
 
   // Initialize square position and size
   Rectangle square = {screenWidth / 2 - 20, screenHeight / 2 - 20, 40, 40};
@@ -29,18 +35,26 @@ int main()
   camera.fovy = 45.0f;                             // Camera field-of-view Y
   camera.projection = CAMERA_PERSPECTIVE;          // Camera mode type
 
-  SetTargetFPS(60); // Set the target frame rate to 60 FPS
-
-  // Main game loop
-  while (!WindowShouldClose())
+// Run the game loop for web
+#if defined(PLATFORM_WEB)
+  emscripten_set_main_loop(UpdateAndDrawFrame, 60, 1);
+#else
+  // Run the game loop for desktop platforms
+  SetTargetFPS(60);            // Set our game to run at 60 frames-per-second
+  while (!WindowShouldClose()) // Detect window close button or ESC key
   {
-    UpdateGame();
-    DrawGame();
+    UpdateAndDrawFrame();
   }
-
-  // Close Raylib window and clean up resources
-  CloseWindow();
+#endif
+  // De-Initialization
+  CloseWindow(); // Close window and OpenGL context
   return 0;
+}
+
+void UpdateAndDrawFrame()
+{
+  UpdateGame();
+  DrawGame();
 }
 
 void UpdateGame()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 #include "raylib.h"
 #include "raymath.h"
-#include <stdlib.h>
 #include "player.h"
 
 #if defined(PLATFORM_WEB)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,10 +13,39 @@ static Player player = Player(0.0f, 0.0f, 0.0f, 2.0f);
 static Vector3 playerVelocity = {0.0f, 0.0f, 0.0f};
 static const float playerSpeed = 5.0f;
 
-// Function declarations
-static void UpdateAndDrawFrame();
-static void UpdateGame();
-static void DrawGame();
+void UpdateGame()
+{
+  playerVelocity = {0.0f, 0.0f, 0.0f};
+  // Update player position based on arrow key input
+  if (IsKeyDown(KEY_LEFT))
+    playerVelocity.x -= 1.0;
+  if (IsKeyDown(KEY_RIGHT))
+    playerVelocity.x += 1.0;
+  if (IsKeyDown(KEY_UP))
+    playerVelocity.z -= 1.0;
+  if (IsKeyDown(KEY_DOWN))
+    playerVelocity.z += 1.0;
+
+  playerVelocity = Vector3Scale(Vector3Normalize(playerVelocity), playerSpeed * GetFrameTime());
+  player.move(playerVelocity);
+}
+
+void DrawGame()
+{
+  BeginDrawing();
+  ClearBackground(RAYWHITE);
+  BeginMode3D(camera);
+  player.draw();
+  EndMode3D();
+  DrawFPS(10, 10);
+  EndDrawing();
+}
+
+void UpdateAndDrawFrame()
+{
+  UpdateGame();
+  DrawGame();
+}
 
 int main()
 {
@@ -46,38 +75,4 @@ int main()
   // De-Initialization
   CloseWindow(); // Close window and OpenGL context
   return 0;
-}
-
-void UpdateAndDrawFrame()
-{
-  UpdateGame();
-  DrawGame();
-}
-
-void UpdateGame()
-{
-  playerVelocity = {0.0f, 0.0f, 0.0f};
-  // Update player position based on arrow key input
-  if (IsKeyDown(KEY_LEFT))
-    playerVelocity.x -= 1.0;
-  if (IsKeyDown(KEY_RIGHT))
-    playerVelocity.x += 1.0;
-  if (IsKeyDown(KEY_UP))
-    playerVelocity.z -= 1.0;
-  if (IsKeyDown(KEY_DOWN))
-    playerVelocity.z += 1.0;
-
-  playerVelocity = Vector3Scale(Vector3Normalize(playerVelocity), playerSpeed * GetFrameTime());
-  player.move(playerVelocity);
-}
-
-void DrawGame()
-{
-  BeginDrawing();
-  ClearBackground(RAYWHITE);
-  BeginMode3D(camera);
-  player.draw();
-  EndMode3D();
-  DrawFPS(10, 10);
-  EndDrawing();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 #include "raylib.h"
 #include "raymath.h"
 #include <stdlib.h>
-#include "Player.h"
+#include "player.h"
 
 #if defined(PLATFORM_WEB)
 #include <emscripten/emscripten.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@ int main()
 
 // Run the game loop for web
 #if defined(PLATFORM_WEB)
-  emscripten_set_main_loop(UpdateAndDrawFrame, 60, 1);
+  emscripten_set_main_loop(UpdateAndDrawFrame, 0, 1);
 #else
   // Run the game loop for desktop platforms
   SetTargetFPS(60);            // Set our game to run at 60 frames-per-second

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1,6 +1,6 @@
 #include "raylib.h"
 #include "raymath.h"
-#include "Player.h"
+#include "player.h"
 
 Player::Player(float x, float y, float z, float size)
 {


### PR DESCRIPTION
Took a while but emscripten works:

Does it work when:

- You install the latest version via setup-emsdk GitHub Actions? No 🙂 
- You install the version available to Ubuntu by default? Yes, it builds it correctly, but throws a random error. So no 🙂 
- You install the latest version from their Git repo? No, no, no! 🙂 

After determining that the issue had to be with how Emscripten was setup with some local testing, I got it working to a fixed version of 3.1.15 when installed via their git repo.

Note for later, g++ and clang++ can build for case insensitive header files e.g. Player.h or player.h doesn't make a difference. But emcc/em++ needs them to match exactly.